### PR TITLE
Fixes bug where packets containing null characters get truncated on reception

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -5,7 +5,7 @@ project_name = "renet"
 
 def apply_gemspec_defaults(s)
 	s.name = "renet"
-	s.version = "0.1.13"
+	s.version = "0.1.14"
 	s.date = Time.now.strftime '%Y-%m-%d'
 	s.author = "Dahrkael"
 	s.email = "dark.wolf.warrior@gmail.com"

--- a/ext/renet/renet_connection.c
+++ b/ext/renet/renet_connection.c
@@ -192,7 +192,7 @@ VALUE renet_connection_update(VALUE self, VALUE timeout)
             break;
 
 			case ENET_EVENT_TYPE_RECEIVE:
-					renet_connection_execute_on_packet_receive(connection->event->packet->data, connection->event->channelID);
+					renet_connection_execute_on_packet_receive(connection->event->packet->dataLength, connection->event->packet->data, connection->event->channelID);
 					enet_packet_destroy(connection->event->packet);
             break;
            
@@ -282,12 +282,12 @@ VALUE renet_connection_on_packet_receive(VALUE self, VALUE method)
 	return Qnil;
 }*/
 
-void renet_connection_execute_on_packet_receive(enet_uint8* data, enet_uint8 channelID)
+void renet_connection_execute_on_packet_receive(size_t data_length, enet_uint8* data, enet_uint8 channelID)
 {
 	VALUE method = rb_iv_get(cENetConnection, "@on_packet_receive");
 	if (method != Qnil)
 	{
-		rb_funcall(method, rb_intern("call"), 2, rb_str_new2(data), UINT2NUM(channelID));
+		rb_funcall(method, rb_intern("call"), 2, rb_str_new(data, data_length), UINT2NUM(channelID));
 	}
 }
 

--- a/ext/renet/renet_connection.h
+++ b/ext/renet/renet_connection.h
@@ -48,7 +48,7 @@ void renet_connection_execute_on_connection();
 
 VALUE renet_connection_on_packet_receive(VALUE self, VALUE method);
 /*VALUE renet_connection_on_packet_receive(int argc, VALUE *argv, VALUE self);*/
-void renet_connection_execute_on_packet_receive(enet_uint8* data, enet_uint8 channelID);
+void renet_connection_execute_on_packet_receive(size_t data_length, enet_uint8* data, enet_uint8 channelID);
 
 VALUE renet_connection_on_disconnection(VALUE self, VALUE method);
 void renet_connection_execute_on_disconnection();

--- a/ext/renet/renet_server.c
+++ b/ext/renet/renet_server.c
@@ -165,7 +165,7 @@ VALUE renet_server_update(VALUE self, VALUE timeout)
 
 			case ENET_EVENT_TYPE_RECEIVE:
 				peer_id = (int)(server->event->peer - server->host->peers);
-				renet_server_execute_on_packet_receive(INT2NUM(peer_id), server->event->packet->data, server->event->channelID);
+				renet_server_execute_on_packet_receive(INT2NUM(peer_id), server->event->packet->dataLength, server->event->packet->data, server->event->channelID);
 				enet_packet_destroy(server->event->packet);
             break;
            
@@ -239,12 +239,12 @@ VALUE renet_server_on_packet_receive(VALUE self, VALUE method)
 	return Qnil;
 }
 
-void renet_server_execute_on_packet_receive(VALUE peer_id, enet_uint8* data, enet_uint8 channelID)
+void renet_server_execute_on_packet_receive(VALUE peer_id, size_t data_length, enet_uint8* data, enet_uint8 channelID)
 {
 	VALUE method = rb_iv_get(cENetServer, "@on_packet_receive");
 	if (method != Qnil)
 	{
-		rb_funcall(method, rb_intern("call"), 3, peer_id, rb_str_new2(data), UINT2NUM(channelID));
+		rb_funcall(method, rb_intern("call"), 3, peer_id, rb_str_new(data, data_length), UINT2NUM(channelID));
 	}
 }
 

--- a/ext/renet/renet_server.h
+++ b/ext/renet/renet_server.h
@@ -47,7 +47,7 @@ VALUE renet_server_on_connection(VALUE self, VALUE method);
 void renet_server_execute_on_connection(VALUE peer_id, VALUE ip);
 
 VALUE renet_server_on_packet_receive(VALUE self, VALUE method);
-void renet_server_execute_on_packet_receive(VALUE peer_id, enet_uint8* data, enet_uint8 channelID);
+void renet_server_execute_on_packet_receive(VALUE peer_id, size_t data_length, enet_uint8* data, enet_uint8 channelID);
 
 VALUE renet_server_on_disconnection(VALUE self, VALUE method);
 void renet_server_execute_on_disconnection(VALUE peer_id);


### PR DESCRIPTION
On packet reception, the packet data was marshaled into ruby using the rb_str_new2() which uses strlen to compute length (which simple counts up to the first null character). This was causing packets to get truncated to the first null in the packet data. I fixed the issue by using rb_str_new() and feeding it the data length in the packet structure.
